### PR TITLE
Ensure linter runs whenever python changes or csv updates on main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,16 +1,20 @@
 name: CSV Lint on CSV File Changes
 
 on:
-  pull_request:
+  push:
     paths:
       - "data/raw/**.csv"
+      - ".github/workflows/lint.yml"
+  pull_request:
+    paths:
+      - "**.py"
       - ".github/workflows/lint.yml"
 
 jobs:
   csv-lint:
     runs-on: ubuntu-latest
     permissions:
-      contents: read  # Read access to the repository contents is enough for linting
+      contents: read # Read access to the repository contents is enough for linting
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
## Updates

- Relax rules to let linter to run on 
  - push to main whenever csv updates
  - pull request for python changes as a guard rail.

## Testing Steps

- Testing with Github actions.

## Notes

-
